### PR TITLE
Move init from ui to events and prep for backend

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -1,11 +1,11 @@
 'use strict'
-const commonUi = require('./common/ui')
+const commonEvents = require('./common/events')
 const authEvents = require('./auth/events')
 const postViewEvents = require('./post-view/events')
 const postFormEvents = require('./post-form/events')
 
 $(() => {
-  commonUi.init()
+  commonEvents.init()
   authEvents.addHandlers()
   postViewEvents.addHandlers()
   postFormEvents.addHandlers()

--- a/assets/scripts/common/api.js
+++ b/assets/scripts/common/api.js
@@ -1,0 +1,17 @@
+const config = require('../config')
+const store = require('../store')
+
+// TODO: unsure if we need token here, remove if it's causing issues
+const getUserHome = () => {
+  return $.ajax({
+    url: config.apiUrl + '/posts',
+    method: 'GET',
+    headers: {
+      Authorization: `Token token=${store.user.token}`
+    }
+  })
+}
+
+module.exports = {
+  getUserHome
+}

--- a/assets/scripts/common/events.js
+++ b/assets/scripts/common/events.js
@@ -1,17 +1,24 @@
 const api = require('./api')
 const ui = require('./ui')
+const navUi = require('../nav/ui.js')
 
-const onGetUserHome = () => {
+const init = () => {
+  navUi.loadNavPublic()
+  onLoadUserHome()
+}
+
+const onLoadUserHome = () => {
   ui.loadHome()
-  // TODO: placeholder for GETing all posts
+  // TODO: placeholder for GETing all posts. Uncomment this and delete the above line when backend is ready for GET /posts
   // api
   //   .getUserHome()
-  //   .then(ui.getUserHomeSuccess)
+  //   .then(data => ui.loadHome(data))
   //   .catch((err) =>
   //     console.warn(err)
   //   );
 }
 
 module.exports = {
-  onGetUserHome
+  onLoadUserHome,
+  init
 }

--- a/assets/scripts/common/ui.js
+++ b/assets/scripts/common/ui.js
@@ -1,17 +1,11 @@
 const home = require('../templates/Home.handlebars')
-const navUi = require('../nav/ui.js')
 
-const init = () => {
-  navUi.loadNavPublic()
-  loadHome()
-}
-
+// TODO: when GET to /posts is working, update this function to accept data from the api and throw it into handlebars
 const loadHome = () => {
   const homeHtml = home()
   $('#content').html(homeHtml)
 }
 
 module.exports = {
-  init,
   loadHome
 }

--- a/assets/scripts/nav/events.js
+++ b/assets/scripts/nav/events.js
@@ -1,17 +1,4 @@
 const api = require('./api')
 const ui = require('./ui')
 
-const onGetUserHome = () => {
-  ui.loadHome()
-  // TODO: placeholder for GETing all posts
-  // api
-  //   .getUserHome()
-  //   .then(ui.getUserHomeSuccess)
-  //   .catch((err) =>
-  //     console.warn(err)
-  //   );
-}
-
-module.exports = {
-  onGetUserHome
-}
+module.exports = {}


### PR DESCRIPTION
The init function (which loads the public navbar and the home page) lived in the ui file as a placeholder. I took this and moved it to events, since it will eventually make an api call and actually load real data.