### PR TITLE
Updating comments sends the correct info - not yet tested with backend

### DIFF
--- a/assets/scripts/post-view/api.js
+++ b/assets/scripts/post-view/api.js
@@ -30,8 +30,20 @@ const updatePost = (id, formData) => {
   })
 }
 
+const updateComment = (id, formData) => {
+  return $.ajax({
+    url: config.apiUrl + '/comments/' + id,
+    method: 'PATCH',
+    headers: {
+      Authorization: `Token token=${store.user.token}`
+    },
+    data: formData
+  })
+}
+
 module.exports = {
   getPost,
   addComment,
-  updatePost
+  updatePost,
+  updateComment
 }

--- a/assets/scripts/post-view/events.js
+++ b/assets/scripts/post-view/events.js
@@ -52,10 +52,35 @@ const onCreateComment = e => {
     .catch(err => console.log(err))
 }
 
+const onUpdateComment = e => {
+  e.preventDefault()
+  // grab the form data
+  const form = e.target
+  const updateCommentData = getFormFields(form)
+  // grab the comment id
+  const commentId = $(event.target)
+    .closest('div.comment-container')
+    .data('id')
+  // grab the post id
+  const postId = $(event.target)
+    .closest('div.post-container')
+    .data('id')
+  // add the post id to the form data
+  updateCommentData.comment.post = postId
+  // send it to the API and then reload the post page. If extra time,
+  // see if we can refresh just the comments section
+  api
+    .updateComment(commentId, updateCommentData)
+    .then(() => api.getPost(postId))
+    .then(res => ui.loadPostView(res))
+    .catch(err => console.log(err))
+}
+
 const addHandlers = event => {
   $('#content').on('click', '.post', onClickPost)
   $('#content').on('submit', '#update-post', onUpdatePost)
   $('#content').on('submit', '#new-comment', onCreateComment)
+  $('#content').on('submit', '.update-comment', onUpdateComment)
 }
 
 module.exports = {

--- a/assets/scripts/templates/PostView.handlebars
+++ b/assets/scripts/templates/PostView.handlebars
@@ -1,8 +1,7 @@
 <div data-id='{{data.post._id}}' class='post-container'>
-
   <form id="update-post">
     <input name="post[title]" type="text" placeholder="Post Title">
-    <textarea name="post[content]" placeholder="Comment Body" rows="5" cols="32"></textarea>
+    <textarea name="post[content]" placeholder="Post Body" rows="5" cols="32"></textarea>
     <button class="btn">Update post</button>
   </form>
   <h1>{{ data.post.title }}</h1>
@@ -17,9 +16,12 @@
   {{#each data.post.comments as |comment|}}
   <div data-id='{{comment._id}}' data-author='{{comment.author}}' class="comment-container">
     {{comment.content}}
+    <form class="update-comment">
+      <textarea name="comment[content]" placeholder="Comment Body" rows="5" cols="32"></textarea>
+      <button class="btn">Update comment</button>
+    </form>
   </div>
   {{else}}
   No comments yet
   {{/each}}
-
 </div>


### PR DESCRIPTION
The comment update form is now sending modified formData that contains what the CommentSchema wants (the comment content and its post id), along with the comment id via params.
The backend is currently giving a 500 error, but I believe this is because the update comments route is still in progress. This should be tested once the backend is ready, and may require changes depending on the result.

Work in progress for #51