### PR TITLE
Update the comment update form to send to the new endpoint

### DIFF
--- a/assets/scripts/post-view/api.js
+++ b/assets/scripts/post-view/api.js
@@ -40,9 +40,9 @@ const deletePost = id => {
   })
 }
 
-const updateComment = (id, formData) => {
+const updateComment = (postId, commentId, formData) => {
   return $.ajax({
-    url: config.apiUrl + '/comments/' + id,
+    url: config.apiUrl + '/comments/' + postId + '/' + commentId,
     method: 'PATCH',
     headers: {
       Authorization: `Token token=${store.user.token}`

--- a/assets/scripts/post-view/events.js
+++ b/assets/scripts/post-view/events.js
@@ -70,15 +70,15 @@ const onUpdateComment = e => {
   updateCommentData.comment.post = postId
   // send it to the API and then reload the post page. If extra time,
   // see if we can refresh just the comments section
+  // TODO: do we still need to insert postId into updateCommentData? They'll have it via params, so try removing this if it causes issues
   api
-    .updateComment(commentId, updateCommentData)
+    .updateComment(postId, commentId, updateCommentData)
     .then(() => api.getPost(postId))
     .then(res => ui.loadPostView(res))
     .catch(err => console.log(err))
 }
 
 const onDeletePost = event => {
-  console.log('hewwo??')
   event.preventDefault()
   const postId = $(event.target)
     .closest('div.post-container')


### PR DESCRIPTION
We decided that the backend needs to have the commentId and the postId via the params, so we've updated the form to do this.