### PR TITLE
Add editable to post and comments

### DIFF
--- a/assets/scripts/post-view/ui.js
+++ b/assets/scripts/post-view/ui.js
@@ -1,6 +1,31 @@
 const postView = require('../templates/PostView.handlebars')
+const store = require('../store')
 
 const loadPostView = data => {
+  // if the user is signed in, check if signed in user matches the post's owner
+  if (store.user) {
+    const userId = store.user._id
+    const postId = data.post.owner._id
+    const editable = userId == postId ? true : false
+    data.post.editable = editable || false
+
+    // for every comment on the post
+    data.post.comments.map(comment => {
+      // grab the author
+      const commentAuthorId = comment.author
+      // compare it with the user id to find out if owner
+      const commentEditable = userId == commentAuthorId ? true : false
+      // create a new key called 'editable' on the comment object
+      comment.editable = commentEditable
+    })
+    // if the user is not signed in - automatically set post and comments editable to false
+  } else {
+    data.post.editable = false
+    data.post.comments.map(comment => {
+      comment.editable = false
+    })
+  }
+
   const postViewHtml = postView({ data })
   $('#content').html(postViewHtml)
 }


### PR DESCRIPTION
Compared the logged in users id from store with the owner ids on post and comments. Created a new key called editable and set it to true or false based on the comparison.
Co-authored-by: Sean sean243446@gmail.com
Co-authored-by: Henry hminicucci@gmail.com
Co-authored-by: Spencer spencer.r1@outlook.com