### PR TITLE
PostView uses the new editable field to show and hide forms properly

### DIFF
--- a/assets/scripts/post-view/ui.js
+++ b/assets/scripts/post-view/ui.js
@@ -18,12 +18,17 @@ const loadPostView = data => {
       // create a new key called 'editable' on the comment object
       comment.editable = commentEditable
     })
+
+    // also create a new key 'signedIn' which tells us we are an authorized user
+    data.post.signedIn = true
+
     // if the user is not signed in - automatically set post and comments editable to false
   } else {
     data.post.editable = false
     data.post.comments.map(comment => {
       comment.editable = false
     })
+    data.post.signedIn = false
   }
 
   const postViewHtml = postView({ data })

--- a/assets/scripts/templates/PostView.handlebars
+++ b/assets/scripts/templates/PostView.handlebars
@@ -1,27 +1,35 @@
 <div data-id='{{data.post._id}}' class='post-container'>
+  {{#if data.post.editable}}
   <form id="update-post">
     <input name="post[title]" type="text" placeholder="Post Title">
     <textarea name="post[content]" placeholder="Post Body" rows="5" cols="32"></textarea>
     <button class="btn">Update post</button>
   </form>
+  <button id="delete-btn">Delete this post</button>
+  {{/if}}
+
   <h1>{{ data.post.title }}</h1>
   <p>{{ data.post.content }}</p>
   {{!-- TODO: refactor opportunity - make Comments and CommentsList its own components/handlebars  --}}
-  <button id="delete-btn">Delete this post</button>
   <h1>Comments</h1>
+  {{#if data.post.signedIn}}
   <h2>New Comment Form</h2>
   <form id="new-comment">
     <textarea name="comment[content]" placeholder="Comment Body" id="new-comment-body" rows="5" cols="32"></textarea>
     <button class="btn">Create new comment</button>
   </form>
+  {{/if}}
   {{#each data.post.comments as |comment|}}
   <div data-id='{{comment._id}}' data-author='{{comment.author}}' class="comment-container">
     {{comment.content}}
+    {{#if comment.editable}}
     <form class="update-comment">
       <textarea name="comment[content]" placeholder="Comment Body" rows="5" cols="32"></textarea>
       <button class="btn">Update comment</button>
     </form>
     <button class="delete-comment">Delete this comment</button>
+    {{/if}}
+
   </div>
   {{else}}
   No comments yet


### PR DESCRIPTION
If a user is signed in and owns the post, they can see the post edit and delete actions. If the user does not own the post, or is not signed in, they dont see those functions. Same logic with a user owning comments and comment update/delete. Also if a user is not signed, dont show add coment form.